### PR TITLE
updated to more recent version of the 2.x embedding api

### DIFF
--- a/projects/tableau/src/lib/scripts.store.ts
+++ b/projects/tableau/src/lib/scripts.store.ts
@@ -5,6 +5,6 @@ export interface Scripts {
 export const ScriptStore: Scripts[] = [
   {
     name: 'tableau',
-    src: 'https://public.tableau.com/javascripts/api/tableau-2.2.2.min.js',
+    src: 'https://public.tableau.com/javascripts/api/tableau-2.9.1.min.js',
   },
 ];


### PR DESCRIPTION
I noticed that ngx-tableau was still calling the 2.2.2 version of the api, updated it to a more recent 2.9.1 version.
